### PR TITLE
Fix NullReference in relation to Keybinds

### DIFF
--- a/src/main/java/com/frontear/hephaestus/modules/api/Module.java
+++ b/src/main/java/com/frontear/hephaestus/modules/api/Module.java
@@ -3,6 +3,7 @@ package com.frontear.hephaestus.modules.api;
 import com.frontear.hephaestus.Hephaestus;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
 import org.lwjgl.input.Keyboard;
 
 import java.awt.*;
@@ -18,6 +19,7 @@ public class Module {
 
     public Module(String name, int keyCode) {
         module = new KeyBinding(name, keyCode, "");
+        ClientRegistry.registerKeyBinding(module);
 
         this.name = name;
         name_with_keyCode = name + " " + "[" + Keyboard.getKeyName(module.getKeyCode()) + "]";


### PR DESCRIPTION
The problem here was that not registering it made it interfere with the rest of Minecraft, and it handled Keyinput way too early and effectively broke any Keybinds minecraft had set (literally everything in controls wouldn't be callable because of this).