### PR TITLE
Fix artifacting of infobar

### DIFF
--- a/src/main/java/com/frontear/hephaestus/client/HephaestusClient.java
+++ b/src/main/java/com/frontear/hephaestus/client/HephaestusClient.java
@@ -26,10 +26,12 @@ public class HephaestusClient {
     }
 
     @SubscribeEvent
-    public void onGui(RenderGameOverlayEvent event) {
-        uiManager.Draw();
-        for (int i = 0; i < moduleManager.getEnabledModules().size(); i++) {
-            moduleManager.getEnabledModules().get(i).onGui(i);
+    public void onGui(RenderGameOverlayEvent.Post event) {
+        if (event.type == RenderGameOverlayEvent.ElementType.TEXT) {
+            uiManager.Draw();
+            for (int i = 0; i < moduleManager.getEnabledModules().size(); i++) {
+                moduleManager.getEnabledModules().get(i).onGui(i);
+            }
         }
     }
 


### PR DESCRIPTION
This was a doozy. The problem was that drawStringWithShadow would use a different texture from the normal one, and minecraft would not replace the texture for the rest of it's UI elements, therefore causing the textures to be replaced to letters. Additionally, forcing it to be called only when the event is building text can improve performance by reducing the amount of loops it needs to perform, while also holding back error cases like above.